### PR TITLE
fix: Template aliasing for Kirby 4.7.1 support

### DIFF
--- a/site/templates/error.php
+++ b/site/templates/error.php
@@ -1,1 +1,3 @@
-<?php snippet('../templates/layout');
+<?php
+
+require __DIR__ . '/layout.php';

--- a/site/templates/home.php
+++ b/site/templates/home.php
@@ -1,1 +1,3 @@
-<?php snippet('../templates/layout');
+<?php
+
+require __DIR__ . '/layout.php';


### PR DESCRIPTION
Deliberate path traversal in the `snippet()` helper is no longer possible due to security impacts (https://github.com/getkirby/kirby/security/advisories/GHSA-fw82-87p8-v6hp). These fixes make sure that the home and error templates still get rendered correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated template files to use standard PHP inclusion for layout templates instead of CMS-specific methods. This change does not affect visible functionality for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->